### PR TITLE
标记 Docker 发布流程的源提交

### DIFF
--- a/.github/workflows/docker-release-publish.yml
+++ b/.github/workflows/docker-release-publish.yml
@@ -1,4 +1,5 @@
 name: build release docker image
+run-name: build release docker image (${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || inputs.ref }})
 
 on:
   workflow_run:


### PR DESCRIPTION
## 修改内容

- 为 Docker 发布 workflow 增加稳定的 `run-name`
- `workflow_run` 触发时在名称中写入 Native workflow 的完整源提交 SHA
- 手动触发时在名称中写入输入的 ref

## 根因

`workflow_run` 类型的 Actions run 顶层 `headSha` 指向默认分支，而不是触发它的 `release` 提交，导致发布执行器无法按发布提交识别已经成功的 Docker run。

## 影响范围

仅补充运行记录的来源标识，不修改 Dockerfile、Native 完成后触发 Docker 的顺序、镜像构建参数或上传逻辑。

## 验证

- `git diff --check`
- 已确认 Dockerfile 无变更

## 合并顺序

此 PR 应先于 `zrlog-ops` 中对应的等待脚本修复合并。