### PR TITLE
ci: run product security baseline locally

### DIFF
--- a/.github/workflows/security-baseline.yml
+++ b/.github/workflows/security-baseline.yml
@@ -3,6 +3,7 @@ name: Security baseline
 on:
   push:
   pull_request:
+  workflow_dispatch:
   schedule:
     - cron: "23 4 * * 1"
 
@@ -12,8 +13,26 @@ permissions:
   pull-requests: read
 
 jobs:
-  baseline:
-    uses: zrlog/zrlog-ops/.github/workflows/security-baseline.yml@main
-    with:
-      codeql_languages: java-kotlin
-      codeql_build_mode: none
+  codeql:
+    name: CodeQL
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: java-kotlin
+          build-mode: none
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:java-kotlin
+
+  dependency-review:
+    name: Dependency review
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high


### PR DESCRIPTION
## What changed

Run the product repository Security baseline locally on the shared self-hosted runner instead of calling the private `zrlog/zrlog-ops` reusable workflow.

The local workflow keeps the same policy:

- CodeQL for `java-kotlin` in `none` build mode
- Dependency Review blocking high-severity additions
- fork PR guard before using the self-hosted runner
- push, pull request, weekly schedule, and manual triggers

## Root cause

`94fzb/zrlog` is outside the `zrlog` organization. GitHub does not allow this personal-owner repository to call a reusable workflow from the private organization repository, so every recent Security baseline run failed during workflow resolution with zero jobs.

The current 17 high CodeQL alerts refer to paths that no longer exist in the v3.9.0 candidate. A successful scan of the current branch is required for GitHub to close those stale alerts.

## Validation

- workflow YAML parsed by `zrlog-ops/scripts/check-release-security-config.py`
- `bash zrlog-ops/scripts/check-ops-guides.sh`
- `git diff --check`
