### PR TITLE
ci: use GitHub-hosted security runners

### DIFF
--- a/.github/workflows/security-baseline.yml
+++ b/.github/workflows/security-baseline.yml
@@ -17,7 +17,7 @@ jobs:
   codeql:
     name: CodeQL
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: github/codeql-action/init@v3
@@ -31,7 +31,7 @@ jobs:
   dependency-review:
     name: Dependency review
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/dependency-review-action@v4

--- a/.github/workflows/security-baseline.yml
+++ b/.github/workflows/security-baseline.yml
@@ -8,6 +8,7 @@ on:
     - cron: "23 4 * * 1"
 
 permissions:
+  actions: read
   contents: read
   security-events: write
   pull-requests: read


### PR DESCRIPTION
## Summary

- grant the Security baseline token read access to Actions workflow runs
- run public-repository CodeQL and dependency review on GitHub-hosted runners
- avoid requiring a self-hosted runner registered to the separate `94fzb` owner

## Validation

- workflow YAML parse
- cross-repository security baseline configuration check
- git diff --check