### PR TITLE
release: merge v3.9.0 candidate back to master

### DIFF
--- a/package/pom.xml
+++ b/package/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.hibegin</groupId>
         <artifactId>zrlog-web-parent</artifactId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>3.9.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>package</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,12 @@
     <parent>
         <groupId>com.hibegin</groupId>
         <artifactId>zrlog-base</artifactId>
-        <version>3.5.9-SNAPSHOT</version>
+        <version>3.5.9</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>zrlog-web-parent</artifactId>
     <packaging>pom</packaging>
-    <version>3.9.0-SNAPSHOT</version>
+    <version>3.9.0</version>
     <modules>
         <module>zrlog-web</module>
         <module>package</module>
@@ -30,9 +30,9 @@
         <lambda-scope>compile</lambda-scope>
         <zrlog-polyglot-template-scope>provided</zrlog-polyglot-template-scope>
         <servlet-api.version>6.1.0</servlet-api.version>
-        <zrlog-install-web.version>3.3.7-SNAPSHOT</zrlog-install-web.version>
-        <zrlog-blog-web.version>3.5.8-SNAPSHOT</zrlog-blog-web.version>
-        <zrlog-admin-web.version>3.5.9-SNAPSHOT</zrlog-admin-web.version>
+        <zrlog-install-web.version>3.3.7</zrlog-install-web.version>
+        <zrlog-blog-web.version>3.5.8</zrlog-blog-web.version>
+        <zrlog-admin-web.version>3.5.9</zrlog-admin-web.version>
         <junit.version>4.13.2</junit.version>
         <mysql-scope>compile</mysql-scope>
     </properties>
@@ -139,7 +139,7 @@
             <dependency>
                 <groupId>com.hibegin</groupId>
                 <artifactId>zrlog-web</artifactId>
-                <version>3.9.0-SNAPSHOT</version>
+                <version>3.9.0</version>
             </dependency>
             <dependency>
                 <groupId>com.mysql</groupId>

--- a/zrlog-web/pom.xml
+++ b/zrlog-web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>zrlog-web-parent</artifactId>
         <groupId>com.hibegin</groupId>
-        <version>3.9.0-SNAPSHOT</version>
+        <version>3.9.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>zrlog-web</artifactId>


### PR DESCRIPTION
## Purpose

Merge the existing v3.9.0 GA candidate commit `e01437c` back into `master` before preparing a corrected release candidate.

The first candidate exposed a Windows-only native artifact path bug after the immutable tag was created. PR #234 fixed the workflow on `master`. Merging the existing release commit back first keeps the corrected candidate on a fast-forward lineage from the current `release` branch.

## Follow-up

After this PR is merged, a separate engineering PR will restore the three project POMs to `3.9.0-SNAPSHOT`. The next human-approved Release Order can then generate a corrected GA commit containing the Windows workflow fix without force-pushing `release`.

The existing `v3.9.0` tag must remain untouched until the snapshot follow-up and replacement Release Order are ready.
