### PR TITLE
release: restore v3.9.0 snapshot for retry

### DIFF
--- a/package/pom.xml
+++ b/package/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.hibegin</groupId>
         <artifactId>zrlog-web-parent</artifactId>
-        <version>3.9.0</version>
+        <version>3.9.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>package</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,12 +3,12 @@
     <parent>
         <groupId>com.hibegin</groupId>
         <artifactId>zrlog-base</artifactId>
-        <version>3.5.9</version>
+        <version>3.5.9-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>zrlog-web-parent</artifactId>
     <packaging>pom</packaging>
-    <version>3.9.0</version>
+    <version>3.9.0-SNAPSHOT</version>
     <modules>
         <module>zrlog-web</module>
         <module>package</module>
@@ -30,9 +30,9 @@
         <lambda-scope>compile</lambda-scope>
         <zrlog-polyglot-template-scope>provided</zrlog-polyglot-template-scope>
         <servlet-api.version>6.1.0</servlet-api.version>
-        <zrlog-install-web.version>3.3.7</zrlog-install-web.version>
-        <zrlog-blog-web.version>3.5.8</zrlog-blog-web.version>
-        <zrlog-admin-web.version>3.5.9</zrlog-admin-web.version>
+        <zrlog-install-web.version>3.3.7-SNAPSHOT</zrlog-install-web.version>
+        <zrlog-blog-web.version>3.5.8-SNAPSHOT</zrlog-blog-web.version>
+        <zrlog-admin-web.version>3.5.9-SNAPSHOT</zrlog-admin-web.version>
         <junit.version>4.13.2</junit.version>
         <mysql-scope>compile</mysql-scope>
     </properties>
@@ -139,7 +139,7 @@
             <dependency>
                 <groupId>com.hibegin</groupId>
                 <artifactId>zrlog-web</artifactId>
-                <version>3.9.0</version>
+                <version>3.9.0-SNAPSHOT</version>
             </dependency>
             <dependency>
                 <groupId>com.mysql</groupId>

--- a/zrlog-web/pom.xml
+++ b/zrlog-web/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>zrlog-web-parent</artifactId>
         <groupId>com.hibegin</groupId>
-        <version>3.9.0</version>
+        <version>3.9.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>zrlog-web</artifactId>


### PR DESCRIPTION
## Purpose

Restore the three project POMs to the exact `3.9.0-SNAPSHOT` state used before the first v3.9.0 GA candidate was generated.

The first candidate exposed a Windows-only native artifact path bug after its tag was created. PR #234 fixed the workflow, and PR #236 merged the old release candidate into `master` so the corrected candidate remains a fast-forward descendant of the current `release` branch.

## Result

Relative to the original approved source commit `1cdb242`, the retry source tree differs only in `.github/workflows/native-build-release-package-zip.yml`. A new human-approved Release Order can therefore regenerate the same v3.9.0 GA version and upstream dependency coordinates while including the Windows fix.

The existing `v3.9.0` tag must remain untouched until the replacement Release Order is ready for approval.

## Validation

- `git diff --check`
- `xmllint --noout pom.xml package/pom.xml zrlog-web/pom.xml`
- `mvn -q -N -DskipTests validate`
- verified `origin/release` is an ancestor of this commit
- verified the retry tree differs from `1cdb242` only by the native workflow fix
