### PR TITLE
Fix Aliyun Docker release compatibility

### DIFF
--- a/.github/workflows/docker-release-publish.yml
+++ b/.github/workflows/docker-release-publish.yml
@@ -110,8 +110,8 @@ jobs:
           username: 90xchun
           password: ${{ secrets.ALIYUN_DOCKER_PASSWORD }}
 
-      - name: Build and push immutable Linux image
-        id: push
+      - name: Build and push immutable Linux image to Docker Hub
+        id: push_dockerhub
         if: needs.prepare.outputs.push_image == 'true'
         uses: docker/build-push-action@v7
         with:
@@ -124,12 +124,57 @@ jobs:
             ZRLOG_CHANNEL=release
             CACHE_BUST=${{ github.run_id }}-${{ github.run_attempt }}
           outputs: >-
-            type=image,"name=${{ env.DOCKERHUB_IMAGE }},${{ env.ALIYUN_IMAGE }}",push-by-digest=true,name-canonical=true,push=true
+            type=image,name=${{ env.DOCKERHUB_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Build and push immutable Linux image to Aliyun
+        id: push_aliyun
+        if: needs.prepare.outputs.push_image == 'true'
+        uses: docker/build-push-action@v7
+        with:
+          context: ./docker
+          file: ./docker/Dockerfile
+          platforms: ${{ matrix.platform }}
+          provenance: false
+          sbom: false
+          build-args: |
+            ZRLOG_CHANNEL=release
+            CACHE_BUST=${{ github.run_id }}-${{ github.run_attempt }}
+          outputs: >-
+            type=image,name=${{ env.ALIYUN_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+
+      - name: Resolve and compare Linux image digests
+        id: image
+        if: needs.prepare.outputs.push_image == 'true'
+        env:
+          ARCH: ${{ matrix.arch }}
+          DOCKERHUB_OUTPUT_DIGEST: ${{ steps.push_dockerhub.outputs.digest }}
+          ALIYUN_DIGEST: ${{ steps.push_aliyun.outputs.digest }}
+        run: |
+          set -euo pipefail
+          : "${DOCKERHUB_OUTPUT_DIGEST:?Docker Hub output digest is required}"
+          : "${ALIYUN_DIGEST:?Aliyun image digest is required}"
+
+          dockerhub_manifest=$(docker buildx imagetools inspect \
+            "${DOCKERHUB_IMAGE}@${DOCKERHUB_OUTPUT_DIGEST}" --raw)
+          dockerhub_image_digest=$(jq -r --arg arch "${ARCH}" '
+            [.manifests[]?
+              | select(.platform.os == "linux" and .platform.architecture == $arch)
+              | .digest]
+            | if length == 1 then .[0] else empty end
+          ' <<<"${dockerhub_manifest}")
+          if [[ -z "${dockerhub_image_digest}" ]]; then
+            dockerhub_image_digest="${DOCKERHUB_OUTPUT_DIGEST}"
+          fi
+          if [[ "${dockerhub_image_digest}" != "${ALIYUN_DIGEST}" ]]; then
+            echo "Linux image digest differs between registries" >&2
+            exit 1
+          fi
+          echo "digest=${dockerhub_image_digest}" >> "${GITHUB_OUTPUT}"
 
       - name: Verify pushed Linux image
         if: needs.prepare.outputs.push_image == 'true'
         env:
-          IMAGE_DIGEST: ${{ steps.push.outputs.digest }}
+          IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
         run: |
           : "${IMAGE_DIGEST:?image digest is required}"
           docker run --rm --entrypoint /opt/zrlog/zrlog \
@@ -138,7 +183,7 @@ jobs:
       - name: Export Linux image digest
         if: needs.prepare.outputs.push_image == 'true'
         env:
-          IMAGE_DIGEST: ${{ steps.push.outputs.digest }}
+          IMAGE_DIGEST: ${{ steps.image.outputs.digest }}
         run: |
           : "${IMAGE_DIGEST:?image digest is required}"
           mkdir -p /tmp/digests

--- a/doc/artifact-verification.md
+++ b/doc/artifact-verification.md
@@ -64,5 +64,7 @@ Linux Docker 镜像的 manifest 应同时包含 `linux/amd64` 和 `linux/arm64`�
 2022 镜像使用 `<version>-windows-ltsc2022` 独立标签；不要把 Linux 和 Windows 标签视为可
 互换的运行环境。
 
-Docker BuildKit 同时为 Linux 镜像生成 SBOM 和 provenance。Linux、Windows 镜像都会对
-发布后的不可变 digest 进行签名。部署系统应固定 digest；版本标签只用于发现。
+Docker BuildKit 为 Docker Hub 中的 Linux 镜像生成 SBOM 和 provenance。阿里云仓库不接受
+BuildKit 使用的 OCI 附属 manifest，因此 workflow 会单独推送不含附属 manifest 的同一平台
+镜像，并在发布多架构 manifest 前验证两端平台镜像 digest 完全一致。Linux、Windows 镜像都会
+对发布后的不可变 digest 进行签名。部署系统应固定 digest；版本标签只用于发现。


### PR DESCRIPTION
## Summary

- push BuildKit SBOM/provenance only to Docker Hub, whose registry accepts the OCI attestation manifests
- push the same platform image to Aliyun without unsupported attestation manifests
- resolve and compare the real platform image digests before publishing the multi-architecture manifest
- document the registry-specific attestation behavior

## Release blocker

ZrLog 3.9.2 Docker run `32644578914` failed for both Linux architectures with `unknown manifest class for application/vnd.oci.empty.v1+json` while pushing to Aliyun. Windows publication succeeded.

## Verification

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/docker-release-publish.yml`
- `git diff --check`
- digest resolver samples for OCI index and plain image manifest

Full-repository actionlint only reports the pre-existing custom runner label `macos-15-intel`; the modified workflow passes.