### PR TITLE
Verify Docker platform digests across registries

### DIFF
--- a/.github/workflows/docker-release-publish.yml
+++ b/.github/workflows/docker-release-publish.yml
@@ -265,6 +265,7 @@ jobs:
           fi
 
           dockerhub_sources=()
+          aliyun_sources=()
           for digest_file in "${digest_files[@]}"; do
             digest="sha256:${digest_file}"
             dockerhub_source="${DOCKERHUB_IMAGE}@${digest}"
@@ -272,18 +273,17 @@ jobs:
             docker buildx imagetools inspect "${dockerhub_source}" >/dev/null
             docker buildx imagetools inspect "${aliyun_source}" >/dev/null
             dockerhub_sources+=("${dockerhub_source}")
+            aliyun_sources+=("${aliyun_source}")
           done
 
           docker buildx imagetools create \
             --tag "${DOCKERHUB_IMAGE}:${DOCKER_TAG_VERSION}" \
             --tag "${DOCKERHUB_IMAGE}:latest" \
             "${dockerhub_sources[@]}"
-          dockerhub_digest="sha256:$(docker buildx imagetools inspect \
-            "${DOCKERHUB_IMAGE}:${DOCKER_TAG_VERSION}" --raw | sha256sum | cut -d' ' -f1)"
           docker buildx imagetools create \
             --tag "${ALIYUN_IMAGE}:${DOCKER_TAG_VERSION}" \
             --tag "${ALIYUN_IMAGE}:latest" \
-            "${DOCKERHUB_IMAGE}@${dockerhub_digest}"
+            "${aliyun_sources[@]}"
 
           validate_manifest() {
             local image="$1"
@@ -297,13 +297,33 @@ jobs:
           validate_manifest "${DOCKERHUB_IMAGE}:${DOCKER_TAG_VERSION}"
           validate_manifest "${ALIYUN_IMAGE}:${DOCKER_TAG_VERSION}"
 
-          aliyun_digest="sha256:$(docker buildx imagetools inspect \
-            "${ALIYUN_IMAGE}:${DOCKER_TAG_VERSION}" --raw | sha256sum | cut -d' ' -f1)"
-          if [[ "${dockerhub_digest}" != "${aliyun_digest}" ]]; then
-            echo "Linux manifest digest differs between registries" >&2
+          platform_digests() {
+            local image="$1"
+            docker buildx imagetools inspect "${image}" --raw | jq -cS '
+              [.manifests[]
+                | select(.platform.os == "linux")
+                | {
+                    platform: "\(.platform.os)/\(.platform.architecture)",
+                    digest: .digest
+                  }]
+              | sort_by(.platform)
+            '
+          }
+          dockerhub_platforms=$(platform_digests "${DOCKERHUB_IMAGE}:${DOCKER_TAG_VERSION}")
+          aliyun_platforms=$(platform_digests "${ALIYUN_IMAGE}:${DOCKER_TAG_VERSION}")
+          if [[ "${dockerhub_platforms}" != "${aliyun_platforms}" ]]; then
+            echo "Linux platform digests differ between registries" >&2
             exit 1
           fi
+
+          dockerhub_digest="sha256:$(docker buildx imagetools inspect \
+            "${DOCKERHUB_IMAGE}:${DOCKER_TAG_VERSION}" --raw | sha256sum | cut -d' ' -f1)"
+          aliyun_digest="sha256:$(docker buildx imagetools inspect \
+            "${ALIYUN_IMAGE}:${DOCKER_TAG_VERSION}" --raw | sha256sum | cut -d' ' -f1)"
+          echo "Docker Hub manifest: ${DOCKERHUB_IMAGE}@${dockerhub_digest}"
+          echo "Aliyun manifest: ${ALIYUN_IMAGE}@${aliyun_digest}"
           echo "dockerhub=${DOCKERHUB_IMAGE}@${dockerhub_digest}" >> "${GITHUB_OUTPUT}"
+          echo "aliyun=${ALIYUN_IMAGE}@${aliyun_digest}" >> "${GITHUB_OUTPUT}"
 
       - name: Inspect published Linux image
         run: |

--- a/doc/artifact-verification.md
+++ b/doc/artifact-verification.md
@@ -66,5 +66,7 @@ Linux Docker 镜像的 manifest 应同时包含 `linux/amd64` 和 `linux/arm64`�
 
 Docker BuildKit 为 Docker Hub 中的 Linux 镜像生成 SBOM 和 provenance。阿里云仓库不接受
 BuildKit 使用的 OCI 附属 manifest，因此 workflow 会单独推送不含附属 manifest 的同一平台
-镜像，并在发布多架构 manifest 前验证两端平台镜像 digest 完全一致。Linux、Windows 镜像都会
-对发布后的不可变 digest 进行签名。部署系统应固定 digest；版本标签只用于发现。
+镜像，并在发布多架构 manifest 前验证两端平台镜像 digest 完全一致。由于 Docker Hub 的 index
+额外包含 attestation descriptor，两端的多架构 index digest 应分别记录，不能要求二者相同。
+Linux、Windows 镜像都会对发布后的不可变 digest 进行签名。部署系统应固定 digest；版本标签
+只用于发现。


### PR DESCRIPTION
## Summary

- independently assemble the Docker Hub and Aliyun Linux indexes from their verified platform manifests
- compare the final `{platform,digest}` sets instead of requiring byte-identical indexes
- keep Docker Hub SBOM/provenance descriptors while excluding unsupported attestation descriptors from Aliyun
- report both registry index digests and sign the canonical Docker Hub digest
- document why the two index digests legitimately differ

## Release blocker

Run `32646317506` proved that copying the Docker Hub index also copies its two BuildKit attestation manifests, which Aliyun rejects with `unknown manifest class for application/vnd.oci.empty.v1+json`. The platform images themselves published and matched successfully in both registries.

## Verification

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.7 .github/workflows/docker-release-publish.yml`
- platform digest normalization sample with an attested Docker Hub index and a plain Aliyun index
- `git diff --check`