### PR TITLE
test: prevent install setup tests from fetching versions

### DIFF
--- a/zrlog-web/src/test/java/com/zrlog/web/setup/install/TestZrLogConfig.java
+++ b/zrlog-web/src/test/java/com/zrlog/web/setup/install/TestZrLogConfig.java
@@ -47,6 +47,11 @@ class TestZrLogConfig extends ZrLogConfig {
     }
 
     @Override
+    public boolean isTest() {
+        return true;
+    }
+
+    @Override
     public DataSourceWrapper configDatabase() throws Exception {
         if (failConfigDatabase) {
             throw new IllegalStateException("database unavailable");


### PR DESCRIPTION
The newly added not-installed InstallWebSetup tests construct ZrLogInstallConfig, whose prefetchVersion path performs a network version check unless the config reports test mode. Mark TestZrLogConfig as test-only so the tests remain offline and Maven can exit reliably. Verified with: ./mvnw -Dmaven.repo.local=/tmp/zrlog-m2 -q -pl zrlog-web -am -DskipTests=false -Dmaven.test.skip=false test